### PR TITLE
wip mold take 2

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -107,6 +107,7 @@ module Puma
       return if mold_candidate.nil?
 
       if mold_candidate.booted?
+        log "- Promoting worker 0 to be the mold"
         mold_candidate.mold!
         @workers.delete mold_candidate
         @mold = mold_candidate

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -86,7 +86,7 @@ module Puma
           end
         end
         # if there's still a @mold at this point, progress to KILL
-        @mold.term if @mold
+        @mold&.term
       end
 
       # if the mold is not pinging, send it a TERM and let it die next iteration

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -98,6 +98,9 @@ module Puma
         end
       end
 
+      # if we still have a mold, we're good, no promoting
+      return if @mold
+
       # if there's a good mold candidate, promote it
       # otherwise wait another iteration
       mold_candidate = worker_at(0)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -73,7 +73,7 @@ module Puma
       return if missing_workers.zero?
 
       # worker has been terminated previously, see if it's finished
-      if @mold.term?
+      if @mold&.term?
         begin
           # if process is dead and a child process, erase the mold
           @mold = nil if Process.wait(@mold.pid, Process::WNOHANG)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -231,7 +231,7 @@ module Puma
       timeout_workers
       wait_workers
       cull_workers
-      promote_mold
+      promote_mold if @options[:fork_worker]
       spawn_workers
 
       if all_workers_booted?

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -132,7 +132,7 @@ module Puma
 
         if fork_worker && @mold
           set_proc_title "mold"
-          @config.run_hooks(:before_mold, nil, @log_writer, @hook_data)
+          @config.run_hooks(:before_molding, nil, @log_writer, @hook_data)
           fork_worker_loop
         end
 

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -23,6 +23,7 @@ module Puma
         @last_checkin = Time.now
         @last_status = {}
         @term = false
+        @mold = false
       end
 
       attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
@@ -49,6 +50,15 @@ module Puma
 
       def term?
         @term
+      end
+
+      def mold!
+        Process.kill("URG", @pid)
+        @mold = true
+      end
+
+      def mold?
+        @mold
       end
 
       STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*), "busy_threads":(?<busy_threads>\d*) }/

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,6 +303,7 @@ module Puma
       PIPE_TERM = "t"
       PIPE_PING = "p"
       PIPE_IDLE = "i"
+      PIPE_MOLD_TERM = "m"
     end
   end
 end

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,7 +303,6 @@ module Puma
       PIPE_TERM = "t"
       PIPE_PING = "p"
       PIPE_IDLE = "i"
-      PIPE_MOLD_TERM = "m"
     end
   end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -876,6 +876,10 @@ module Puma
       process_hook :after_refork, key, block, 'after_refork'
     end
 
+    def before_molding(key = nil, &block)
+      process_hook :before_molding, key, block, 'before_molding'
+    end
+
     # Provide a block to be executed just before a thread is added to the thread
     # pool. Be careful: while the block executes, thread creation is delayed, and
     # probably a request will have to wait too! The new thread will not be added to

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -348,35 +348,6 @@ class TestIntegrationCluster < TestIntegration
     refute_includes pids, get_worker_pids(1, wrkrs - 1)
   end
 
-  # use three workers to keep accepting clients
-  def test_fork_worker_after_refork
-    refork = Tempfile.new 'refork2'
-    wrkrs = 3
-    cli_server "-w #{wrkrs} test/rackup/hello_with_delay.ru", config: <<~RUBY
-      fork_worker 20
-      on_refork { File.write '#{refork.path}', 'Before refork', mode: 'a+' }
-      after_refork { File.write '#{refork.path}', '-After refork', mode: 'a+' }
-    RUBY
-
-    pids = get_worker_pids 0, wrkrs
-
-    socks = []
-    until refork.read == 'Before refork-After refork'
-      refork.rewind
-      socks << fast_connect
-      sleep 0.004
-    end
-
-    100.times {
-      socks << fast_connect
-      sleep 0.004
-    }
-
-    socks.each { |s| read_body s }
-
-    refute_includes pids, get_worker_pids(1, wrkrs - 1)
-  end
-
   def test_fork_worker_spawn
     cli_server '', config: <<~CONFIG
       workers 1


### PR DESCRIPTION
## WIP for discussion and testing only

### Description
See discussion at https://github.com/puma/puma/issues/3596.

After dealing with excessive complexity in an earlier attempt, I settled on a simpler approach here that allows the cluster parent to spawn workers directly if there is not a suitable mold process available. This means that at initial boot, all workers will be coming off the cluster parent. If at any point in the future the mold process terminates, the cluster parent will also take over responsibility for replacing workers until the old mold is cleaned up and a new one can be promoted. IMO this is the best option as there are already no guarantees about worker parentage with refork, and it is strictly better to have workers descending from the cluster parent than being orphaned.

I've also got an internal repo up implementing a wrapper around PR_SET_CHILD_SUBREAPER (where available) that I'm working on getting open sourced and publicly available that I think would be a good addition to this PR, as it would cement the cluster parent's role as a potential worker parent in any kind of edge cases. I'm not fully convinced that it should be up to the library rather than the app to implement this though (one of the reasons I pulled it out into a separate gem); my working example is that on our app, we have to make changes to our process manager setup to account for the reparenting, and know that it works in our production environment, so it makes more sense for me to implement it appropriately in our Puma setup than for Puma to automatically apply that kind of nuanced behavior change. Not a particularly strongly-held opinion either way.

For now this limits mold candidacy to worker zero, but this isn't an essential restriction and can likely be removed later.

I've decided to repurpose URG on workers to be the signal to stop serving and promote to mold; it looks like that behavior is currently undefined.

### TODO:
- [ ] Test molding at request count limit
- [ ] Test molding at phased restart
- [ ] Test molding after mold times out health checks
- [ ] Test molding after mold process unexpectedly terminates
- [ ] Test functional behavior in preprod
- [ ] Test functional behavior in prod

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
