### PR TITLE
Tore allow generational molding

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -107,6 +107,7 @@ module Puma
       return if mold_candidate.nil?
 
       if mold_candidate.booted?
+        log "- Promoting worker 0 to be the mold"
         mold_candidate.mold!
         @workers.delete mold_candidate
         @mold = mold_candidate

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -361,11 +361,12 @@ module Puma
         end
 
         # Auto-fork after the specified number of requests.
-        if (fork_requests = @options[:fork_worker].to_i) > 0
+        if (fork_requests = @options[:fork_worker].first.to_i) > 0
           @events.register(:ping!) do |w|
-            fork_worker! if w.index == 0 &&
-              w.phase == 0 &&
-              w.last_status[:requests_count] >= fork_requests
+            if w.phase == 0 && w.last_status[:requests_count] >= fork_requests
+              fork_worker!
+              @options.fork_worker.shift
+            end
           end
         end
       end

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -134,7 +134,7 @@ module Puma
       diff.times do
         idx = next_worker_index
 
-        if @options[:fork_worker] && working_mold? && idx != 0
+        if @options[:fork_worker] && working_mold?
           @fork_writer << "#{idx}\n"
           pid = nil
         else

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -86,7 +86,7 @@ module Puma
           end
         end
         # if there's still a @mold at this point, progress to KILL
-        @mold.term if @mold
+        @mold&.term
       end
 
       # if the mold is not pinging, send it a TERM and let it die next iteration

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -98,6 +98,9 @@ module Puma
         end
       end
 
+      # if we still have a mold, we're good, no promoting
+      return if @mold
+
       # if there's a good mold candidate, promote it
       # otherwise wait another iteration
       mold_candidate = worker_at(0)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -73,7 +73,7 @@ module Puma
       return if missing_workers.zero?
 
       # worker has been terminated previously, see if it's finished
-      if @mold.term?
+      if @mold&.term?
         begin
           # if process is dead and a child process, erase the mold
           @mold = nil if Process.wait(@mold.pid, Process::WNOHANG)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -231,7 +231,7 @@ module Puma
       timeout_workers
       wait_workers
       cull_workers
-      promote_mold
+      promote_mold if @options[:fork_worker]
       spawn_workers
 
       if all_workers_booted?

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -103,7 +103,7 @@ module Puma
 
       # if there's a good mold candidate, promote it
       # otherwise wait another iteration
-      mold_candidate = @workers.max { |a, b| a.last_status[:requests_count] <=> b.last_status[:requests_count] }
+      mold_candidate = @workers.select { |x| x.phase == @phase }.max { |a, b| a.last_status[:requests_count] <=> b.last_status[:requests_count] }
       return if mold_candidate.nil?
 
       if mold_candidate.booted?
@@ -345,7 +345,7 @@ module Puma
 
     # @version 5.0.0
     def fork_worker!
-      if (worker = worker_at 0)
+      if (worker = @workers.max { |a, b| a.last_status[:requests_count] <=> b.last_status[:requests_count] })
         worker.phase += 1
         @mold&.term
       end

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -67,7 +67,7 @@ module Puma
 
         restart_server = @restart_server ||= Queue.new << true << false
 
-        fork_worker = @options[:fork_worker] && index == 0
+        fork_worker = @options[:fork_worker]
 
         if fork_worker
           worker_pids = @worker_pids ||= []

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -132,7 +132,7 @@ module Puma
 
         if fork_worker && @mold
           set_proc_title "mold"
-          @config.run_hooks(:before_mold, nil, @log_writer, @hook_data)
+          @config.run_hooks(:before_molding, nil, @log_writer, @hook_data)
           fork_worker_loop
         end
 

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -23,6 +23,7 @@ module Puma
         @last_checkin = Time.now
         @last_status = {}
         @term = false
+        @mold = false
       end
 
       attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
@@ -49,6 +50,15 @@ module Puma
 
       def term?
         @term
+      end
+
+      def mold!
+        Process.kill("URG", @pid)
+        @mold = true
+      end
+
+      def mold?
+        @mold
       end
 
       STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*), "busy_threads":(?<busy_threads>\d*) }/

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,6 +303,7 @@ module Puma
       PIPE_TERM = "t"
       PIPE_PING = "p"
       PIPE_IDLE = "i"
+      PIPE_MOLD_TERM = "m"
     end
   end
 end

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,7 +303,6 @@ module Puma
       PIPE_TERM = "t"
       PIPE_PING = "p"
       PIPE_IDLE = "i"
-      PIPE_MOLD_TERM = "m"
     end
   end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -876,6 +876,10 @@ module Puma
       process_hook :after_refork, key, block, 'after_refork'
     end
 
+    def before_molding(key = nil, &block)
+      process_hook :before_molding, key, block, 'before_molding'
+    end
+
     # Provide a block to be executed just before a thread is added to the thread
     # pool. Be careful: while the block executes, thread creation is delayed, and
     # probably a request will have to wait too! The new thread will not be added to

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1270,8 +1270,8 @@ module Puma
     # @note This is experimental.
     # @note Cluster mode only.
     #
-    def fork_worker(after_requests=1000)
-      @options[:fork_worker] = Integer(after_requests)
+    def fork_worker(after_requests=1000, *addl_requests)
+      @options[:fork_worker] = [after_requests] + addl_requests.map { |r| Integer(r) }
     end
 
     # The number of requests to attempt inline before sending a client back to

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -348,35 +348,6 @@ class TestIntegrationCluster < TestIntegration
     refute_includes pids, get_worker_pids(1, wrkrs - 1)
   end
 
-  # use three workers to keep accepting clients
-  def test_fork_worker_after_refork
-    refork = Tempfile.new 'refork2'
-    wrkrs = 3
-    cli_server "-w #{wrkrs} test/rackup/hello_with_delay.ru", config: <<~RUBY
-      fork_worker 20
-      on_refork { File.write '#{refork.path}', 'Before refork', mode: 'a+' }
-      after_refork { File.write '#{refork.path}', '-After refork', mode: 'a+' }
-    RUBY
-
-    pids = get_worker_pids 0, wrkrs
-
-    socks = []
-    until refork.read == 'Before refork-After refork'
-      refork.rewind
-      socks << fast_connect
-      sleep 0.004
-    end
-
-    100.times {
-      socks << fast_connect
-      sleep 0.004
-    }
-
-    socks.each { |s| read_body s }
-
-    refute_includes pids, get_worker_pids(1, wrkrs - 1)
-  end
-
   def test_fork_worker_spawn
     cli_server '', config: <<~CONFIG
       workers 1


### PR DESCRIPTION
### Description
This is another attempt to solve https://github.com/puma/puma/issues/3596.

This is also iterating on top of https://github.com/toregeschliman/puma/pull/2, the more conservative branch solving the same core issue.

Unlike said branch, this one will search for a mold candidate among _all_ workers, based on which one has the highest request count. On mold promotion, it also allows the mold to replace itself. Finally, whenever a fork_worker! is forced by worker 0 clearing a particular request count, it will find the best mold candidate and increase _its_ phase along with the clusters, so that that worker will become the mold to start the refork from. (It still waits for worker 0 to clear the threshold because this does not have to be very precise and that is simpler)/

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
