### PR TITLE
Inline child subreaper

### DIFF
--- a/ext/puma_http11/child_subreaper.h
+++ b/ext/puma_http11/child_subreaper.h
@@ -1,0 +1,19 @@
+#ifndef CHILD_SUBREAPER_H
+#define CHILD_SUBREAPER_H 1
+
+#include "ruby.h"
+#ifdef HAVE_CONST_PR_SET_CHILD_SUBREAPER
+#include <sys/prctl.h>
+static VALUE child_subreaper_enable(VALUE module) {
+  if (prctl(PR_SET_CHILD_SUBREAPER, 1) < 0) {
+    rb_sys_fail("prctl(2) PR_SET_CHILD_SUBREAPER");
+  }
+  return Qtrue;
+}
+#else
+static VALUE child_subreaper_enable(VALUE module) {
+  return Qfalse;
+}
+#endif
+
+#endif /* CHILD_SUBREAPER_H */

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -8,6 +8,8 @@ if $mingw
   have_library 'ssp'
 end
 
+have_const("PR_SET_CHILD_SUBREAPER", "sys/prctl.h")
+
 unless ENV["PUMA_DISABLE_SSL"]
   # don't use pkg_config('openssl') if '--with-openssl-dir' is used
   has_openssl_dir = dir_config('openssl').any? ||

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "http11_parser.h"
+#include "child_subreaper.h"
 
 #ifndef MANAGED_STRINGS
 
@@ -477,6 +478,8 @@ void Init_puma_http11(void)
 
   eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eStandardError);
   rb_global_variable(&eHttpParserError);
+
+  rb_define_singleton_method(mPuma, "enable_child_subreaper", child_subreaper_enable, 0);
 
   rb_define_alloc_func(cHttpParser, HttpParser_alloc);
   rb_define_method(cHttpParser, "initialize", HttpParser_init, 0);

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -467,6 +467,8 @@ module Puma
 
       @config.run_hooks(:before_fork, nil, @log_writer)
 
+      Puma.enable_child_subreaper if @options[:fork_worker] || @options[:mold_worker]
+
       spawn_workers
 
       Signal.trap "SIGINT" do


### PR DESCRIPTION
move child_subreaper functionality into puma and automatically enable it (or try to) where appropriate